### PR TITLE
Escape slashes

### DIFF
--- a/test_urlize.js
+++ b/test_urlize.js
@@ -118,16 +118,16 @@ test('autoescape == false', function () {
 
 test('autoescape == true', function () {
   equal(urlize('This <b>is</b> www.ljosa.com', true, true),
-   'This &lt;b&gt;is&lt;&#47;b&gt; <a href="http://www.ljosa.com" rel="nofollow">www.ljosa.com</a>');
+   'This &lt;b&gt;is&lt;/b&gt; <a href="http://www.ljosa.com" rel="nofollow">www.ljosa.com</a>');
   equal(urlize('This <b>is</b> www.ljosa.com', {nofollow: true, autoescape: true}),
-   'This &lt;b&gt;is&lt;&#47;b&gt; <a href="http://www.ljosa.com" rel="nofollow">www.ljosa.com</a>');
+   'This &lt;b&gt;is&lt;/b&gt; <a href="http://www.ljosa.com" rel="nofollow">www.ljosa.com</a>');
 });
 
 test('trim_url_limit', function () {
   equal(urlize('When you go to www.nemeet.com/somethinglong, you will find it.', false, true, 20),
-   'When you go to <a href="http://www.nemeet.com/somethinglong">www.nemeet.com&#47;so...</a>, you will find it.');
+   'When you go to <a href="http://www.nemeet.com/somethinglong">www.nemeet.com/so...</a>, you will find it.');
   equal(urlize('When you go to www.nemeet.com/somethinglong, you will find it.', {autoescape: true, trim_url_limit: 20}),
-   'When you go to <a href="http://www.nemeet.com/somethinglong">www.nemeet.com&#47;so...</a>, you will find it.');
+   'When you go to <a href="http://www.nemeet.com/somethinglong">www.nemeet.com/so...</a>, you will find it.');
 });
 
 test('No target parameter', function () {
@@ -160,9 +160,9 @@ test('autoescape == False and ampersands', function () {
 
 test('autoescape == True and ampersands', function () {
   equal(urlize('http://foo.bar/?a=1&b=2', false, true),
-   '<a href="http://foo.bar/?a=1&amp;b=2">http:&#47;&#47;foo.bar&#47;?a=1&amp;b=2</a>');
+   '<a href="http://foo.bar/?a=1&amp;b=2">http://foo.bar/?a=1&amp;b=2</a>');
   equal(urlize('http://foo.bar/?a=1&b=2', {autoescape: true}),
-   '<a href="http://foo.bar/?a=1&amp;b=2">http:&#47;&#47;foo.bar&#47;?a=1&amp;b=2</a>');
+   '<a href="http://foo.bar/?a=1&amp;b=2">http://foo.bar/?a=1&amp;b=2</a>');
 });
 
 test('autoescape == False and troublesome ampersands', function () {
@@ -174,14 +174,14 @@ test('autoescape == False and troublesome ampersands', function () {
 
 test('autoescape == True and troublesome ampersands', function () {
   equal(urlize('http://foo.bar/?a=1&amp;=2', false, true),
-   '<a href="http://foo.bar/?a=1&amp;amp;=2">http:&#47;&#47;foo.bar&#47;?a=1&amp;amp;=2</a>');
+   '<a href="http://foo.bar/?a=1&amp;amp;=2">http://foo.bar/?a=1&amp;amp;=2</a>');
   equal(urlize('http://foo.bar/?a=1&amp;=2', {autoescape: true}),
-   '<a href="http://foo.bar/?a=1&amp;amp;=2">http:&#47;&#47;foo.bar&#47;?a=1&amp;amp;=2</a>');
+   '<a href="http://foo.bar/?a=1&amp;amp;=2">http://foo.bar/?a=1&amp;amp;=2</a>');
 });
 
 test('autoescape == True and double quotes', function () {
   equal(urlize('http://foo.bar/evilquote"/>script', false, true),
-    '<a href="http://foo.bar/evilquote%22/%3Escript">http:&#47;&#47;foo.bar&#47;evilquote&quot;&#47;&gt;script</a>');
+    '<a href="http://foo.bar/evilquote%22/%3Escript">http://foo.bar/evilquote&quot;/&gt;script</a>');
 });
 
 test('Mixed-case protocol', function () {
@@ -278,29 +278,36 @@ test('enclosing fancy single quotes', function () {
 });
 
 test('enclosing double quotes', function () {
-    equal(urlize('The link "http://example.com" is broken'),
+  equal(urlize('The link "http://example.com" is broken'),
 	  'The link "http://example.com" is broken');
-    equal(urlize('The link "http://example.com" is broken', {django_compatible: false}),
+  equal(urlize('The link "http://example.com" is broken', {django_compatible: false}),
 	  'The link "<a href="http://example.com">http://example.com</a>" is broken');
-    equal(urlize('The link "www.example.com" is broken'),
+  equal(urlize('The link "www.example.com" is broken'),
 	  'The link "www.example.com" is broken');
-    equal(urlize('The link "www.example.com" is broken', {django_compatible: false}),
+  equal(urlize('The link "www.example.com" is broken', {django_compatible: false}),
 	  'The link "<a href="http://www.example.com">www.example.com</a>" is broken');
+});
+
+test('autoescape = TRUE replaces "/" with "&#47;"', function() {
+  equal(urlize('The link http://example.com with escaped / slashes', {autoescape: true}),
+    'The link <a href="http://example.com">http://example.com</a> with escaped / slashes');
+  equal(urlize('The link http://example.com with escaped / slashes', {django_compatible: false, autoescape: true}),
+    'The link <a href=\"http://example.com\">http:&#47;&#47;example.com</a> with escaped &#47; slashes');
 });
 
 // PENDING
 // test('Colon before', function () {
-//     equal(urlize('Here is the link:http://example.com'),
+//   equal(urlize('Here is the link:http://example.com'),
 // 	  'Here is the <a href="http://link:http://example.com">link:http://example.com</a>');
-//     equal(urlize('Here is the link:http://example.com', {django_compatible: false}),
+//   equal(urlize('Here is the link:http://example.com', {django_compatible: false}),
 // 	  'Here is the link:<a href="http://example.com">http://example.com</a>');
-//     equal(urlize('Here is the link:www.example.com'),
+//   equal(urlize('Here is the link:www.example.com'),
 // 	  'Here is the <a href="http://link:www.example.com">link:www.example.com</a>');
-//     equal(urlize('Here is the link:www.example.com', {django_compatible: false}),
+//   equal(urlize('Here is the link:www.example.com', {django_compatible: false}),
 // 	  'Here is the link:<a href="http://www.example.com">www.example.com</a>');
 // });
 
-test ('End trim period and paren', function () {
-    equal(urlize('(Go to http://www.ljosa.priv.no/foo.)', {django_compatible: false}),
+test('End trim period and paren', function () {
+  equal(urlize('(Go to http://www.ljosa.priv.no/foo.)', {django_compatible: false}),
 	  '(Go to <a href="http://www.ljosa.priv.no/foo">http://www.ljosa.priv.no/foo</a>.)');
 });

--- a/urlize.js
+++ b/urlize.js
@@ -171,14 +171,17 @@ var urlize = (function () {
   var simple_url_2_re = /^www\.|^(?!http)\w[^@]+\.(com|edu|gov|int|mil|net|org)$/i;
   var simple_email_re = /^\S+@\S+\.\S+$/;
 
-  function htmlescape(html) {
-    return html
+  function htmlescape(html, options) {
+    var escaped = html
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#39;")
-      .replace(/\//g, "&#47;");
+      .replace(/'/g, "&#39;");
+    if (options && !options.django_compatible) { // only on django_compatible because => https://github.com/ljosa/urlize.js/pull/9
+      escaped = escaped.replace(/\//g, "&#47;");
+    }
+    return escaped
   }
 
   function urlescape(url) {
@@ -265,10 +268,10 @@ var urlize = (function () {
           var trimmed = trim_url(middle);
           if (options.autoescape) {
             // XXX: Assuming autoscape == false
-            lead = htmlescape(lead);
-            trail = htmlescape(trail);
+            lead = htmlescape(lead, options);
+            trail = htmlescape(trail, options);
             url = urlescape(url);
-            trimmed = htmlescape(trimmed);
+            trimmed = htmlescape(trimmed, options);
           }
           middle = '<a href="' + url + '"' + nofollow_attr + target_attr + '>' + trimmed + '</a>';
           words[i] = lead + middle + trail;
@@ -276,13 +279,13 @@ var urlize = (function () {
           if (safe_input) {
             // Do nothing, as we have no mark_safe.
           } else if (options.autoescape) {
-            words[i] = htmlescape(word);
+            words[i] = htmlescape(word, options);
           }
         }
       } else if (safe_input) {
         // Do nothing, as we have no mark_safe.
       } else if (options.autoescape) {
-        words[i] = htmlescape(word);
+        words[i] = htmlescape(word, options);
       }
     }
     return words.join('');


### PR DESCRIPTION
### What

Add support for slash.
- When auto_escape is true, then replace `"/"` with `"&#47;"`
- The `simple_url_re` RegExp now recognizes `"http:&#47;&#47;"` as a URL. This allows to urlize a text that was escaped by other library before (it should be the common case IMO)
### Why

I am using urlize.js with haml_coffee_assets templates. A week ago it suddenly stopped working. I finally found it was because an update in their library: https://github.com/netzpirat/haml_coffee_assets/commit/1894b0544622b7ac33955aa21a1161748780bd98

At first I though of complaining in there or modifying the HAML.escape function in my project, but hell, they are right: OWASP suggests you escape it per https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet (see RULE#1).

So, I decided to add support for slash escape in this library instead. Now it works fine.
### Also: Comment broken specs as pending

I found the following test broken in master: "IDN" and "Colon before".
Is not part of this pull request to fix them, but it was confusing to me to see them broken (it took me a little while to realize they were actually broken before my changes), they should be marked as pending (commented out) while they are not fixed. There should never be no red tests in master.
### Also: Correct indentation

I found the code to be indented half with tabs, half with spaces, sometimes with 4 spaces, sometimes with 2 spaces. And sometimes there was a weird "FF" character (not visible in most editors, also not visible here in github. I found it with SublimeText2)
